### PR TITLE
Update regen script to leverage git changes instead of bruteforce-regenerating all icons on every run

### DIFF
--- a/GenerateIssuerIconAssets.sh
+++ b/GenerateIssuerIconAssets.sh
@@ -34,8 +34,9 @@ write_json() {
 EOF
 }
 
+
 cd "$(dirname "$0")"
-for file in ./IssuerIcons/*.png; do
+for file in "$(git ls-files --others --exclude-standard)"; do
   name="$(get_name $file)"
   echo "Generating icon for ${name}"
   imageset="./Tofu/Assets.xcassets/${name}.imageset/"


### PR DESCRIPTION
Instead of `for file in ./IssuerIcons/*.png` we can use `git ls-files --others --exclude-standard` to give us a list of untracked files in the current branch so we can operate only on those files.
The workflow largely remains the same, except now icon contributors will have much smaller commits :)